### PR TITLE
Adds flag to prevent multiple touches opening multiple cards

### DIFF
--- a/src/wtc-perspective-card.js
+++ b/src/wtc-perspective-card.js
@@ -664,12 +664,14 @@ class ClickablePerspectiveCard extends PerspectiveCard {
     // Bind the extra handlers
     this.onClick = this.onClick.bind(this);
     this.onKey = this.onKey.bind(this);
+    this.onPointerDown = this.onPointerDown.bind(this);
 
     // Create the matte - this is the element that will appear behind the card.
     this.matte = document.createElement("div");
     this.matte.className = `perspective-card--matte`;
 
     // Add the listener to the pointer up event
+    this.element.addEventListener("pointerdown", this.onPointerDown);
     this.element.addEventListener("pointerup", this.onClick);
     this.matte.addEventListener("pointerup", this.onClick);
   }

--- a/src/wtc-perspective-card.js
+++ b/src/wtc-perspective-card.js
@@ -2,12 +2,12 @@ const SUPPORTSTOUCH = "ontouchstart" in window || navigator.msMaxTouchPoints;
 const EPSILON = 0.001;
 
 // Easing functions
-const easeInOutCubic = function(time, start, change, duration) {
+const easeInOutCubic = function (time, start, change, duration) {
   if ((time /= duration / 2) < 1)
     return change * 0.5 * time * time * time + start;
   return change * 0.5 * ((time -= 2) * time * time + 2) + start;
 };
-const easeInOutSine = function(time, start, change, duration) {
+const easeInOutSine = function (time, start, change, duration) {
   return (-change / 2) * (Math.cos((Math.PI * time) / duration) - 1) + start;
 };
 
@@ -79,7 +79,7 @@ class PerspectiveCard {
       // Set up and bind the intersection observer
       this.observer = new IntersectionObserver(this.intersect, {
         rootMargin: "0%",
-        threshold: [0.1]
+        threshold: [0.1],
       });
       this.observer.observe(this.element);
     }
@@ -139,7 +139,7 @@ class PerspectiveCard {
       this.center = [
         this.center[0],
         this.center[1],
-        this.center[2] + (this.zoom - this.center[2]) * (divisor * 2)
+        this.center[2] + (this.zoom - this.center[2]) * (divisor * 2),
       ];
     }
 
@@ -154,7 +154,8 @@ class PerspectiveCard {
           (this.tPoint[0] - this.lookPoint[0]) * (divisor * 2),
         this.lookPoint[1] +
           (this.tPoint[1] - this.lookPoint[1]) * (divisor * 2),
-        this.lookPoint[2] + (this.tPoint[2] - this.lookPoint[2]) * (divisor * 2)
+        this.lookPoint[2] +
+          (this.tPoint[2] - this.lookPoint[2]) * (divisor * 2),
       ];
     }
 
@@ -162,7 +163,7 @@ class PerspectiveCard {
     const worldMatrix = PerspectiveCard.targetTo(this.center, this.lookPoint, [
       0,
       1,
-      0
+      0,
     ]);
 
     // Find the polar coordinates for the rendition of the gradient.
@@ -193,7 +194,7 @@ class PerspectiveCard {
     const d = [
       this.lookPoint[0] - this.tPoint[0],
       this.lookPoint[1] - this.tPoint[1],
-      this.lookPoint[2] - this.tPoint[2]
+      this.lookPoint[2] - this.tPoint[2],
     ];
     this._lookDifferential = d[0] * d[0] + d[1] * d[1] + d[2] * d[2];
   }
@@ -214,7 +215,7 @@ class PerspectiveCard {
     this.tPoint = [
       e.clientX - this.axis[0],
       e.clientY - this.axis[1],
-      this.tPoint[2]
+      this.tPoint[2],
     ];
   }
 
@@ -277,7 +278,7 @@ class PerspectiveCard {
       this.size = [pos.width, pos.height];
       this.axis = [
         this.position[0] + this.size[0] * 0.5,
-        this.position[1] + this.size[1] * 0.5
+        this.position[1] + this.size[1] * 0.5,
       ];
     };
     clearTimeout(this.debounceTimer);
@@ -582,7 +583,7 @@ class PerspectiveCard {
       const off = {
         x: e.x - c.x,
         y: e.y - c.y,
-        z: e.z - c.z
+        z: e.z - c.z,
       };
       let l = off.x * off.x + off.y * off.y + off.z * off.z;
       if (l > 0) {
@@ -595,7 +596,7 @@ class PerspectiveCard {
       const or = {
         x: u.y * off.z - u.z * off.y,
         y: u.z * off.x - u.x * off.z,
-        z: u.x * off.y - u.y * off.x
+        z: u.x * off.y - u.y * off.x,
       };
       l = or.x * or.x + or.y * or.y + or.z * or.z;
       if (l > 0) {
@@ -624,7 +625,7 @@ class PerspectiveCard {
         e.x,
         e.y,
         e.z,
-        1
+        1,
       ];
     }
   }
@@ -654,6 +655,11 @@ class ClickablePerspectiveCard extends PerspectiveCard {
   constructor(element, settings) {
     // Call the superfunction
     super(element, settings);
+
+    // We're using this varaible to prevent the user from clicking multiple
+    // perspective cards and having them all open. This will make sure only the
+    // FIRST clicked card will open.
+    window.clickablePerspectiveCard_initialtouch = null;
 
     // Bind the extra handlers
     this.onClick = this.onClick.bind(this);
@@ -691,7 +697,7 @@ class ClickablePerspectiveCard extends PerspectiveCard {
       this.size = [pos.width, pos.height];
       this.axis = [
         this.position[0] + this.size[0] * 0.5,
-        this.position[1] + this.size[1] * 0.5
+        this.position[1] + this.size[1] * 0.5,
       ];
     };
     clearTimeout(this.debounceTimer);
@@ -727,7 +733,7 @@ class ClickablePerspectiveCard extends PerspectiveCard {
           this.startingPosition[1],
           this.targetPosition[1] - this.startingPosition[1],
           this.tweenDuration
-        )
+        ),
       ];
 
       // Tween the card scale
@@ -768,8 +774,18 @@ class ClickablePerspectiveCard extends PerspectiveCard {
   }
 
   // Toggle the enlarged flag on click
-  onClick() {
-    this.enlarged = !this.enlarged;
+  onClick(e) {
+    if (window.clickablePerspectiveCard_initialtouch === e.pointerId) {
+      this.enlarged = !this.enlarged;
+      window.clickablePerspectiveCard_initialtouch = null;
+    }
+  }
+
+  // Toggle the enlarged flag on click
+  onPointerDown(e) {
+    if (window.clickablePerspectiveCard_initialtouch === null) {
+      window.clickablePerspectiveCard_initialtouch = e.pointerId;
+    }
   }
 
   onKey(e) {
@@ -851,14 +867,14 @@ class ClickablePerspectiveCard extends PerspectiveCard {
       // End position
       this.targetPosition = [
         window.innerWidth * 0.5 - this.startingDimensions[0] * 0.5,
-        window.innerHeight * 0.5 - this.startingDimensions[1] * 0.5
+        window.innerHeight * 0.5 - this.startingDimensions[1] * 0.5,
       ];
 
       // Set up the amount of rotation that needs to happen
       this.rotationAmount = Math.PI * -2;
 
       // An empty endTween function for this tween
-      this.onEndTween = function() {};
+      this.onEndTween = function () {};
 
       // If we're going from enlarged to unenlarged
     } else if (this.enlarged === false && wasEnlarged === true) {
@@ -886,7 +902,7 @@ class ClickablePerspectiveCard extends PerspectiveCard {
       this.rotationAmount = Math.PI * 2;
 
       // At the end of this tween we clean everything up
-      this.onEndTween = function() {
+      this.onEndTween = function () {
         document.body.style.overflow = "";
         document.body.style.paddingRight = "";
         document.body.removeChild(this.matte);
@@ -968,7 +984,7 @@ class ClickablePerspectiveCard extends PerspectiveCard {
     }
   }
   get onEndTween() {
-    return this._onEndTween || function() {};
+    return this._onEndTween || function () {};
   }
 
   /**


### PR DESCRIPTION
## Description

An issue occurred on one of our sites where if you clicked on more than one clickable card at once multiple cards would open. 

## Solution

Adds `window.clickablePerspectiveCard_initialtouch` flag to determine if multiple touches have occurred and to only register the initial one. 
