### PR TITLE
Adds tweenBuffer check to pointer event

### DIFF
--- a/src/wtc-perspective-card.js
+++ b/src/wtc-perspective-card.js
@@ -829,7 +829,10 @@ class ClickablePerspectiveCard extends PerspectiveCard {
 
   // Toggle the enlarged flag on click
   onPointerDown(e) {
-    if (window.clickablePerspectiveCard_initialtouch === null) {
+    if (
+      window.clickablePerspectiveCard_initialtouch === null &&
+      this._tweenBuffer === false
+    ) {
       window.clickablePerspectiveCard_initialtouch = e.pointerId;
     }
   }


### PR DESCRIPTION
## Description

When we merged the tweenBuffer (https://github.com/wethegit/wtc-perspective-card/pull/12) we only added the check to the click event and not the pointer event. This was causing an issue in which cards couldn't be closed on devices with touch events. 

## Solution

Adds tweenBuffer check to `onPointerDown()` function.

```
onPointerDown(e) {
    if (
      window.clickablePerspectiveCard_initialtouch === null &&
      this._tweenBuffer === false
    ) {
      window.clickablePerspectiveCard_initialtouch = e.pointerId;
    }
  }
```
