### PR TITLE
Removes 3D transforms when card is enlarged 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wtc-perspective-card",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wtc-perspective-card",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "repository": "git@github.com:wethegit/wtc-perspective-card.git",
   "author": "Liam Egan <liam@wethecollectibe.com>",
   "license": "MIT",

--- a/src/wtc-perspective-card.js
+++ b/src/wtc-perspective-card.js
@@ -74,6 +74,8 @@ class PerspectiveCard {
     );
     this.shine = this.element.querySelector(".perspective-card__shine");
 
+    this.cardImage = this.element.querySelector('.perspective-card [class*="front"]');
+
     // Bind our event listeners
     this.resize = this.resize.bind(this);
     this.pointerMove = this.pointerMove.bind(this);
@@ -922,12 +924,21 @@ class ClickablePerspectiveCard extends PerspectiveCard {
       // Set up the amount of rotation that needs to happen
       this.rotationAmount = Math.PI * -2;
 
-      // An empty endTween function for this tween
-      this.onEndTween = function() {};
+      this.onEndTween = function() {
+        // Transform style preserve 3d, and the translateZ were causing 
+        // the card image to pixelate on non retina monitors. Removing these
+        // whilst the card is open fixes that.
+        this.cardImage.style.transform = "initial";
+        this.transformer.style.transformStyle = "flat";
+      };
 
       // If we're going from enlarged to unenlarged
     } else if (this.enlarged === false && wasEnlarged === true) {
       window.removeEventListener("keyup", this.onKey);
+
+      // Adds 3d transforms back in on close. 
+      this.transformer.style.transformStyle = "preserve-3d";
+      this.cardImage.style.transform = "translateZ(2px)";
 
       // Remove the modal class from the matte
       this.matte.classList.remove("perspective-card--modal");

--- a/src/wtc-perspective-card.js
+++ b/src/wtc-perspective-card.js
@@ -74,8 +74,6 @@ class PerspectiveCard {
     );
     this.shine = this.element.querySelector(".perspective-card__shine");
 
-    this.cardImage = this.element.querySelector('.perspective-card [class*="front"]');
-
     // Bind our event listeners
     this.resize = this.resize.bind(this);
     this.pointerMove = this.pointerMove.bind(this);
@@ -928,17 +926,16 @@ class ClickablePerspectiveCard extends PerspectiveCard {
         // Transform style preserve 3d, and the translateZ were causing 
         // the card image to pixelate on non retina monitors. Removing these
         // whilst the card is open fixes that.
-        this.cardImage.style.transform = "initial";
-        this.transformer.style.transformStyle = "flat";
+        this.element.classList.add("perspective-card--is-open");
+
       };
 
       // If we're going from enlarged to unenlarged
     } else if (this.enlarged === false && wasEnlarged === true) {
       window.removeEventListener("keyup", this.onKey);
 
-      // Adds 3d transforms back in on close. 
-      this.transformer.style.transformStyle = "preserve-3d";
-      this.cardImage.style.transform = "translateZ(2px)";
+      // Adds 3d transforms back in on close.
+      this.element.classList.remove("perspective-card--is-open");
 
       // Remove the modal class from the matte
       this.matte.classList.remove("perspective-card--modal");

--- a/src/wtc-perspective-card.scss
+++ b/src/wtc-perspective-card.scss
@@ -73,3 +73,13 @@
 .perspective-card.perspective-card--modal {
   z-index: 1001;
 }
+
+.perspective-card--is-open {
+  .perspective-card__transformer {
+    transform-style: flat;
+  }
+
+  [class*="front"] {
+    transform: initial;
+  }
+}


### PR DESCRIPTION
## Description

Cards were showing up as pixelated on non-retina monitors when enlarged.

## Solution

When the card is enlarged, I've removed the `transform-style: preserve3d` and switched it to `transform-style: flat`. This goes for the `translateZ` on the card image too. Toggling these bumps the quality up substantially. When the card is closed, I've reverted both of these transform styles to their initial states.
